### PR TITLE
Swift 4.2 support

### DIFF
--- a/Source/LocalizeExtensions.swift
+++ b/Source/LocalizeExtensions.swift
@@ -82,7 +82,12 @@ extension UIButton {
     @objc public func localize() {
         var title = titleLabel?.text
         titleLabel?.text = LocalizeUI.localize(key: &localizeKey, value: &title)
-        for state in [UIControlState.normal, .highlighted, .selected, .disabled] {
+        #if swift(>=4.2)
+        let states: [UIControl.State] = [.normal, .highlighted, .selected, .disabled]
+        #else
+        let states: [UIControlState] = [.normal, .highlighted, .selected, .disabled]
+        #endif
+        for state in states {
             var title = self.title(for: state)
             title = LocalizeUI.localize(key: &localizeKey, value: &title)
             setTitle(title, for: state)


### PR DESCRIPTION
The UIButton extension was referencing `UIControlState`, which changed to `UIControl.State` in Swift 4.2, preventing the project from compiling.

I'm not sure what your policy is on Swift backwards compatibility support, I noticed your `.swift-version` file says `4.1` while the readme says Swift 3.0+, additionally you might consider the inline `#if swift(>=4.2)` check messy, can adjust things if that's your preference!