### PR TITLE
added auto localize flag to UI components

### DIFF
--- a/Localize.xcodeproj/project.pbxproj
+++ b/Localize.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2B41FFEC20AB1A450012AF1E /* OnlyOneLang.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2B41FFE820AB18FE0012AF1E /* OnlyOneLang.strings */; };
 		2B717465207D9AFE0070DC5F /* LocalizeUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B717464207D9AFE0070DC5F /* LocalizeUI.swift */; };
 		2B717469207DC6E00070DC5F /* UIViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B717468207DC6E00070DC5F /* UIViewComponents.swift */; };
+		2B8E83BC2181100A00DB21FB /* UIViewComponentsWithDisabledAutoLocalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8E83BA21810F6500DB21FB /* UIViewComponentsWithDisabledAutoLocalize.swift */; };
 		2B931AA8208302FB00C26D6B /* lang-en.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F761AEB1E3063E400904B4B /* lang-en.json */; };
 		2B931AA92083030400C26D6B /* langTable-en.json in Resources */ = {isa = PBXBuildFile; fileRef = 2BD853262081316E00FB0E53 /* langTable-en.json */; };
 		2B931AAA2083030700C26D6B /* lang-es.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F4570211E3173A4008C37D1 /* lang-es.json */; };
@@ -66,6 +67,7 @@
 		2B80F11B20830FBD00542924 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Storyboard.strings; sourceTree = "<group>"; };
 		2B80F11C20830FBD00542924 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Strings.strings; sourceTree = "<group>"; };
 		2B80F11D20830FBD00542924 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Other.strings; sourceTree = "<group>"; };
+		2B8E83BA21810F6500DB21FB /* UIViewComponentsWithDisabledAutoLocalize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewComponentsWithDisabledAutoLocalize.swift; sourceTree = "<group>"; };
 		2BAA7AA3207FC9F6008E4E3A /* UIViewComponentsES.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewComponentsES.swift; sourceTree = "<group>"; };
 		2BAA7AA5207FCA8B008E4E3A /* UIViewComponentsWithString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewComponentsWithString.swift; sourceTree = "<group>"; };
 		2BB606B82083119100DFEF11 /* lang-fr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "lang-fr.json"; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				2B717468207DC6E00070DC5F /* UIViewComponents.swift */,
 				2BAA7AA3207FC9F6008E4E3A /* UIViewComponentsES.swift */,
 				2BAA7AA5207FCA8B008E4E3A /* UIViewComponentsWithString.swift */,
+				2B8E83BA21810F6500DB21FB /* UIViewComponentsWithDisabledAutoLocalize.swift */,
 				9F989F4A1E2B3B5600A19F67 /* Supporting Files */,
 			);
 			path = Tests;
@@ -392,6 +395,7 @@
 				9FCD8EA51E52AD3E00B5909C /* StringsChanginDefaultFileName.swift in Sources */,
 				9F989F4D1E2B3B8300A19F67 /* OtherLangTest.swift in Sources */,
 				9FA3BC511E318C080054CA92 /* ReadingOtherFiles.swift in Sources */,
+				2B8E83BC2181100A00DB21FB /* UIViewComponentsWithDisabledAutoLocalize.swift in Sources */,
 				2BAA7AA6207FCA8B008E4E3A /* UIViewComponentsWithString.swift in Sources */,
 				2BAA7AA4207FC9F6008E4E3A /* UIViewComponentsES.swift in Sources */,
 				9F19DFC71E4D2B1D00F953E6 /* StringBaseTest.swift in Sources */,

--- a/Source/LocalizeExtensions.swift
+++ b/Source/LocalizeExtensions.swift
@@ -9,7 +9,7 @@ import UIKit
 
 private var localizeKey1: UInt8 = 0
 private var localizeKey2: UInt8 = 1
-private var autoLocalizeKey = "autoLocalizeKey"
+private var autoLocalizeKey: UInt8 = 2
 
 /// Extension for NSCoding, easy way to storage IBInspectable properties.
 extension NSCoding {
@@ -27,13 +27,13 @@ extension NSCoding {
 
     /// Get associated autoLocalize property by IBInspectable var.
     fileprivate func autoLocalizeValue() -> Bool {
-        return objc_getAssociatedObject(self, autoLocalizeKey) as? Bool ?? true
+        return objc_getAssociatedObject(self, &autoLocalizeKey) as? Bool ?? true
     }
 
     /// Set associated autoLocalize property by IBInspectable var.
     fileprivate func setAutoLocalizeValue(value: Bool) {
         let policy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN
-        objc_setAssociatedObject(self, autoLocalizeKey, value, policy)
+        objc_setAssociatedObject(self, &autoLocalizeKey, value, policy)
     }
 }
 

--- a/Source/LocalizeExtensions.swift
+++ b/Source/LocalizeExtensions.swift
@@ -9,6 +9,7 @@ import UIKit
 
 private var localizeKey1: UInt8 = 0
 private var localizeKey2: UInt8 = 1
+private var autoLocalizeKey = "autoLocalizeKey"
 
 /// Extension for NSCoding, easy way to storage IBInspectable properties.
 extension NSCoding {
@@ -22,6 +23,17 @@ extension NSCoding {
         guard let value = value else { return }
         let policy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN
         objc_setAssociatedObject(self, key, value, policy)
+    }
+
+    /// Get associated autoLocalize property by IBInspectable var.
+    fileprivate func autoLocalizeValue() -> Bool {
+        return objc_getAssociatedObject(self, autoLocalizeKey) as? Bool ?? true
+    }
+
+    /// Set associated autoLocalize property by IBInspectable var.
+    fileprivate func setAutoLocalizeValue(value: Bool) {
+        let policy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN
+        objc_setAssociatedObject(self, autoLocalizeKey, value, policy)
     }
 }
 
@@ -40,6 +52,12 @@ extension NotificationCenter {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UIBarButtonItem {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -51,8 +69,10 @@ extension UIBarButtonItem {
     /// Set title for UIBarButtonItem
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -63,6 +83,12 @@ extension UIBarButtonItem {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UIButton {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -74,8 +100,10 @@ extension UIButton {
     /// Set title for UIButton in each state
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -97,6 +125,12 @@ extension UIButton {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UILabel {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -108,8 +142,10 @@ extension UILabel {
     /// Set title for UILabel
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -120,6 +156,12 @@ extension UILabel {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UINavigationItem {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeTitle: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -137,8 +179,10 @@ extension UINavigationItem {
     /// Set title and prompt for UINavigationItem
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -150,6 +194,12 @@ extension UINavigationItem {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UISearchBar {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizePlaceholder: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -167,8 +217,10 @@ extension UISearchBar {
     /// Set title and prompt for UISearchBar
     open override  func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -180,6 +232,12 @@ extension UISearchBar {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UISegmentedControl {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -191,8 +249,10 @@ extension UISegmentedControl {
     /// Set title for UISegmentedControl in each state
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -208,6 +268,12 @@ extension UISegmentedControl {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UITabBarItem {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -219,8 +285,10 @@ extension UITabBarItem {
     /// Set title for UITabBarItem
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -231,6 +299,12 @@ extension UITabBarItem {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UITextField {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeText: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -248,8 +322,10 @@ extension UITextField {
     /// Set title and placeholder for UITextField
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement
@@ -261,6 +337,12 @@ extension UITextField {
 
 /// Extension for UI element is the easier way to localize your keys.
 extension UITextView {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+
     /// Localizable tag storeged property
     @IBInspectable public var localizeKey: String? {
         get { return localizedValueFor(key: &localizeKey1) }
@@ -272,8 +354,10 @@ extension UITextView {
     /// Set title for UITextView
     open override func awakeFromNib() {
         super.awakeFromNib()
-        localize()
-        NotificationCenter.localize(observer: self, selector: #selector(localize))
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
     }
 
     /// Here we change text with key replacement

--- a/Tests/UIViewComponentsWithDisabledAutoLocalize.swift
+++ b/Tests/UIViewComponentsWithDisabledAutoLocalize.swift
@@ -1,0 +1,299 @@
+//
+//  UIViewComponentsWithDisabledAutoLocalize.swift
+//  LocalizeTests
+//
+//  Copyright © 2018 @adbqpa.
+//
+
+import XCTest
+import UIKit
+import Localize
+
+class UIViewComponentsWithDisabledAutoLocalize: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Localize.update(bundle: Bundle(for: type(of: self)))
+        Localize.update(language: "en")
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    // MARK: - UIBarButtonItem
+    func testButtonItemWithLocalizeKey() {
+        let button = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        button.localizeKey = "the.same.lavel"
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.title == "")
+    }
+
+    func testButtonItemWithTextKey() {
+        let button = UIBarButtonItem(title: "the.same.lavel", style: .plain, target: self, action: nil)
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.title == "the.same.lavel")
+    }
+
+    func testButtonItemWithoutKeys() {
+        let button = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.title == nil)
+    }
+
+    // MARK: - UIButton
+    func testButtonWithLocalizeKey() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        button.localizeKey = "the.same.lavel"
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.titleLabel?.text == nil)
+    }
+
+    func testButtonWithTextKey() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        button.titleLabel?.text = "the.same.lavel"
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.titleLabel?.text == "the.same.lavel")
+    }
+
+    func testButtonWithoutKeys() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        button.autoLocalize = false
+        button.awakeFromNib()
+
+        XCTAssertTrue(button.titleLabel?.text == nil)
+    }
+
+    // MARK: - UILabel
+    func testLabelWithLocalizeKey() {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        label.localizeKey = "the.same.lavel"
+        label.autoLocalize = false
+        label.awakeFromNib()
+
+        XCTAssertTrue(label.text == nil)
+    }
+
+    func testLabelWithTextKey() {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        label.text = "the.same.lavel"
+        label.autoLocalize = false
+        label.awakeFromNib()
+
+        XCTAssertTrue(label.text == "the.same.lavel")
+    }
+
+    func testLabelWithoutKeys() {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        label.autoLocalize = false
+        label.awakeFromNib()
+
+        XCTAssertTrue(label.text == nil)
+    }
+
+    // MARK: - UINavigationItem
+    func testNavigationItemWithLocalizeKey() {
+        let item = UINavigationItem(title: "")
+        item.localizeTitle = "the.same.lavel"
+        item.localizePrompt = "the.same.lavel"
+        item.autoLocalize = false
+        item.awakeFromNib()
+
+        XCTAssertTrue(item.title == "")
+        XCTAssertTrue(item.prompt == nil)
+    }
+
+    func testNavigationItemWithTextKey() {
+        let item = UINavigationItem(title: "the.same.lavel")
+        item.prompt = "the.same.lavel"
+        item.autoLocalize = false
+        item.awakeFromNib()
+
+        XCTAssertTrue(item.title == "the.same.lavel")
+        XCTAssertTrue(item.prompt == "the.same.lavel")
+    }
+
+    func testNavigationItemWithoutKeys() {
+        let item = UINavigationItem(title: "")
+        item.autoLocalize = false
+        item.awakeFromNib()
+
+        XCTAssertTrue(item.title == "")
+        XCTAssertTrue(item.prompt == nil)
+    }
+
+    // MARK: - UISearchBar
+    func testSearchBarWithLocalizeKey() {
+        let bar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        bar.localizePlaceholder = "the.same.lavel"
+        bar.localizePrompt = "the.same.lavel"
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.placeholder == nil)
+        XCTAssertTrue(bar.prompt == nil)
+    }
+
+    func testSearchBarWithTextKey() {
+        let bar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        bar.placeholder = "the.same.lavel"
+        bar.prompt = "the.same.lavel"
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.placeholder == "the.same.lavel")
+        XCTAssertTrue(bar.prompt == "the.same.lavel")
+    }
+
+    func testSearchBarWithoutKeys() {
+        let bar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.placeholder == nil)
+        XCTAssertTrue(bar.prompt == nil)
+    }
+
+    // MARK: - UITabBarItem
+    func testTabBarItemWithLocalizeKey() {
+        let bar = UITabBarItem(title: "", image: nil, tag: 0)
+        bar.localizeKey = "the.same.lavel"
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.title == "")
+    }
+
+    func testTabBarItemWithTextKey() {
+        let bar = UITabBarItem(title: "the.same.lavel", image: nil, tag: 0)
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.title == "the.same.lavel")
+    }
+
+    func testTabBarItemWithoutKeys() {
+        let bar = UITabBarItem(title: "", image: nil, tag: 0)
+        bar.autoLocalize = false
+        bar.awakeFromNib()
+
+        XCTAssertTrue(bar.title == "")
+    }
+
+    // MARK: - UITextField
+    func testTextFieldWithLocalizeKey() {
+        let textField = UITextField(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textField.localizeText = "the.same.lavel"
+        textField.localizePlaceholder = "the.same.lavel"
+        textField.autoLocalize = false
+        textField.awakeFromNib()
+
+        XCTAssertTrue(textField.text == "")
+        XCTAssertTrue(textField.placeholder == nil)
+    }
+
+    func testTextFieldWithTextKey() {
+        let textField = UITextField(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textField.text = "the.same.lavel"
+        textField.placeholder = "the.same.lavel"
+        textField.autoLocalize = false
+        textField.awakeFromNib()
+
+        XCTAssertTrue(textField.text == "the.same.lavel")
+        XCTAssertTrue(textField.placeholder == "the.same.lavel")
+    }
+
+    func testTextFieldWithoutKeys() {
+        let textField = UITextField(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textField.autoLocalize = false
+        textField.awakeFromNib()
+
+        XCTAssertTrue(textField.text == "")
+        XCTAssertTrue(textField.placeholder == nil)
+    }
+
+    // MARK: - UITextView
+    func testTextViewWithLocalizeKey() {
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textView.localizeKey = "the.same.lavel"
+        textView.autoLocalize = false
+        textView.awakeFromNib()
+
+        XCTAssertTrue(textView.text == "")
+    }
+
+    func testTextViewWithTextKey() {
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textView.text = "the.same.lavel"
+        textView.autoLocalize = false
+        textView.awakeFromNib()
+
+        XCTAssertTrue(textView.text == "the.same.lavel")
+    }
+
+    func testTextViewWithoutKeys() {
+        let textView = UITextView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        textView.autoLocalize = false
+        textView.awakeFromNib()
+
+        XCTAssertTrue(textView.text == "")
+    }
+
+    // MARK: - UISegmentedControl
+    func testSegmentedControlWithLocalizeKey() {
+        let segment = UISegmentedControl(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        segment.insertSegment(withTitle: "", at: 0, animated: false)
+        segment.insertSegment(withTitle: "", at: 1, animated: false)
+        segment.localizeKey = "one, two"
+        segment.autoLocalize = false
+        segment.awakeFromNib()
+
+        XCTAssertTrue(segment.titleForSegment(at: 0) == "")
+        XCTAssertTrue(segment.titleForSegment(at: 1) == "")
+    }
+
+    func testSegmentedControlWithLocalizeKeyBased() {
+        let segment = UISegmentedControl(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        segment.insertSegment(withTitle: "", at: 0, animated: false)
+        segment.insertSegment(withTitle: "", at: 1, animated: false)
+        segment.localizeKey = "segment.base: one, two"
+        segment.autoLocalize = false
+        segment.awakeFromNib()
+
+        XCTAssertTrue(segment.titleForSegment(at: 0) == "")
+        XCTAssertTrue(segment.titleForSegment(at: 1) == "")
+    }
+
+    func testSegmentedControlWithTextKey() {
+        let segment = UISegmentedControl(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        segment.insertSegment(withTitle: "segment.base.one", at: 0, animated: false)
+        segment.insertSegment(withTitle: "segment.base.two", at: 1, animated: false)
+        segment.autoLocalize = false
+        segment.awakeFromNib()
+
+        XCTAssertTrue(segment.titleForSegment(at: 0) == "segment.base.one")
+        XCTAssertTrue(segment.titleForSegment(at: 1) == "segment.base.two")
+    }
+
+    func testSegmentedControlWithoutKeys() {
+        let segment = UISegmentedControl(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        segment.insertSegment(withTitle: "", at: 0, animated: false)
+        segment.insertSegment(withTitle: "", at: 1, animated: false)
+        segment.autoLocalize = false
+        segment.awakeFromNib()
+
+        XCTAssertTrue(segment.titleForSegment(at: 0) == "")
+        XCTAssertTrue(segment.titleForSegment(at: 1) == "")
+    }
+}


### PR DESCRIPTION
## Secutiry Questions

- [x] You tested your code?
- [x] You keep the code coverage?
- [x] You tested your code?
- [x] You documented it change if is necesary?

**Is your feature request related to a problem? Please describe.**
Changing localization at runtime breaks texts of labels, button and etc that computed at runtime

**Describe the solution you'd like**
I'm add auto localize flag to UI components to be able turn it off when component text will be computed and localized myself at runtime
