### PR TITLE
Fixed #localize with placeholder replacement, when the key is not pro…

### DIFF
--- a/Source/LocalizeCommonProtocol.swift
+++ b/Source/LocalizeCommonProtocol.swift
@@ -139,7 +139,6 @@ open class LocalizeCommonProtocol: LocalizeProtocol {
         tableName: String? = nil) -> String {
 
         var string = localize(key: key, tableName: tableName)
-        if string == key { return key }
         var array = string.components(separatedBy: "%")
         string = ""
 


### PR DESCRIPTION
…vided in the current language.

# PR Description

Removed the early return when the translation is identical to the key on `#localize(values:)`.

## Security Questions

- [x] You tested your code?
- [x] You keep the code coverage?
- [x] You tested your code?
- [x] You documented it change if is necessary?

**Is your feature request related to a problem? Please describe.**

When there is no translation available for a key, but the key itself is a proper text, the placeholder replacement brakes because of early return of the key in the `#localize(values:)` method.

This also breaks, when the key and the "translation" is exactly the same, as it would be with the default language.

That doesn't make sense a lot and is also asymmetrical  to `#localize(value:)` (which got changed by an earlier pull request by me...)
If one doesn't use proper user displayable text as keys but e.g. SOMETHING_LIKE_THIS, it's not much of a degradation to have replacement values concatenated at the end.
Therefore, this line should go.

**Describe the solution you'd like**
Please add my patch. Thanks a lot!


**Describe alternatives you've considered**
I would have used `String(format:)` in the first place for string replacement, as that's the thing you would use with `NSLocalizedText`, too, but that would break compatibility now.

**Additional context**
None available.