### PR TITLE
IBInspectable for UIViewController

### DIFF
--- a/Source/LocalizeExtensions.swift
+++ b/Source/LocalizeExtensions.swift
@@ -367,3 +367,34 @@ extension UITextView {
         text = localize
     }
 }
+
+/// Extension for UI element is the easier way to localize your keys.
+extension UIViewController {
+    /// Auto localize stored property
+    @IBInspectable public var autoLocalize: Bool {
+        get { return autoLocalizeValue() }
+        set { setAutoLocalizeValue(value: newValue) }
+    }
+    
+    /// Localizable tag storeged property
+    @IBInspectable public var localizeTitle: String? {
+        get { return localizedValueFor(key: &localizeKey1) }
+        set { setLocalized(value: newValue, key: &localizeKey1) }
+    }
+    
+    /// Override awakeFromNib when is going visible, try search a key in JSON File
+    /// If key match replace text, if can't match return the key (original text)
+    /// Set title and placeholder for UITextField
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+        if autoLocalize {
+            localize()
+            NotificationCenter.localize(observer: self, selector: #selector(localize))
+        }
+    }
+    
+    /// Here we change text with key replacement
+    @objc public func localize() {
+        LocalizeUI.localize(key: &localizeTitle, value: &title)
+    }
+}


### PR DESCRIPTION
Support localizing the title of UIViewController in Interface Builder.

# PR Description

I add an extension for UIViewController with @IBInspectable. So I can set the localize key for it's title in Interface Builder.

## Security Questions

- [x] You tested your code?
- [x] You keep the code coverage?
- [x] You tested your code?
- [x] You documented it change if is necessary?
