### PR TITLE
 Localize with multiple values bug fix

### DIFF
--- a/Source/LocalizeCommonProtocol.swift
+++ b/Source/LocalizeCommonProtocol.swift
@@ -134,23 +134,15 @@ open class LocalizeCommonProtocol: LocalizeProtocol {
     ///
     /// - returns: localized key or same text
     open func localize(
-        key: String,
-        values replace: [Any],
-        tableName: String? = nil) -> String {
-
-        var string = localize(key: key, tableName: tableName)
-        var array = string.components(separatedBy: "%")
-        string = ""
-
-        for (index, element) in replace.enumerated() where index < array.count {
-            let new = array.remove(at: 0)
-            string = index == 0 ? "\(new)\(element)" : "\(string)\(new)\(element) "
-        }
-
-        string += array.joined(separator: "")
-        string = string.replacingOccurrences(of: "  ", with: " ")
-        return string
+      key: String,
+      values replace: [Any],
+      tableName: String? = nil) -> String {
+      
+      let string = localize(key: key, tableName: tableName)
+      let stringFormat = string.replacingOccurrences(of: "%", with: "%@")
+      return String(format: stringFormat, arguments: replace.map { "\($0)" })
     }
+
 
     /// Localize string with dictionary values
     /// Get properties in your key with rule :property

--- a/Tests/BaseTest.swift
+++ b/Tests/BaseTest.swift
@@ -43,7 +43,7 @@ class BaseTest: XCTestCase {
 
     func testLocalizeKeyWithValues() {
         let localized = "values".localize(values: "Andres", "Software Developer")
-        XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer , see you soon")
+        XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer, see you soon")
     }
 
     func testLocalizeKeyWithDictionary() {

--- a/Tests/BaseTestInSpanish.swift
+++ b/Tests/BaseTestInSpanish.swift
@@ -33,7 +33,7 @@ class BaseTestInSpanish: XCTestCase {
 
     func testLocalizeKeyWithValues() {
         let localized = "values".localize(values: "Andres", "Software Developer")
-        XCTAssertEqual(localized, "Hola a todos mi nombre es Andres y soy Software Developer , nos vemos pronto")
+        XCTAssertEqual(localized, "Hola a todos mi nombre es Andres y soy Software Developer, nos vemos pronto")
     }
 
     func testLocalizeKeyWithDictionary() {

--- a/Tests/StringBaseTest.swift
+++ b/Tests/StringBaseTest.swift
@@ -38,7 +38,17 @@ class StringBaseTest: XCTestCase {
 
     func testLocalizeKeyWithValues() {
         let localized = "values".localize(values: "Andres", "Software Developer")
-        XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer , see you soon")
+        XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer, see you soon")
+    }
+  
+    func testLocalizeKeyWithThreeValues() {
+      let localized = "three_values".localize(values: "Hello" ,"Andres", "Software Developer")
+      XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer, see you soon")
+    }
+  
+    func testLocalizeKeyWithFourValues() {
+      let localized = "four_values".localize(values: "Hello" ,"Andres", "Software Developer", "soon")
+      XCTAssertEqual(localized, "Hello everyone my name is Andres and I'm Software Developer, see you soon")
     }
 
     func testLocalizeKeyWithDictionary() {

--- a/Tests/StringBaseTestInSpanish.swift
+++ b/Tests/StringBaseTestInSpanish.swift
@@ -29,7 +29,7 @@ class StringBaseTestInSpanish: XCTestCase {
 
     func testLocalizeKeyWithValues() {
         let localized = "values".localize(values: "Andres", "Software Developer")
-        XCTAssertEqual(localized, "Hola a todos mi nombre es Andres y soy Software Developer , nos vemos pronto")
+        XCTAssertEqual(localized, "Hola a todos mi nombre es Andres y soy Software Developer, nos vemos pronto")
     }
 
     func testLocalizeKeyWithDictionary() {

--- a/Tests/en.lproj/Strings.strings
+++ b/Tests/en.lproj/Strings.strings
@@ -11,6 +11,10 @@
 
 "values" = "Hello everyone my name is % and I'm %, see you soon";
 
+"three_values" = "% everyone my name is % and I'm %, see you soon";
+
+"four_values" = "% everyone my name is % and I'm %, see you %";
+
 "username" = "My username is :username";
 
 "level.one.two.three" = "This is a multilevel key";


### PR DESCRIPTION
# PR Description

####  The issue with library methods:

1. Localize with values worked incorrectly with 3, 4, (probably more) values to insert. Values were not inserted. 

2. Localize with values worked incorrectly with 2 values: extra space appeared.

#### Bug in tests:

testLocalizeKeyWithValues() method had a misspelling bug, that allowed current library methods pass the test, while working incorrectly in the case 2) 

## Work done:

1. Simplified localize with values method implementation
2. Fixed the bug in testLocalizeKeyWithValues() test method
3. Added tests method to check multiple values insertion

